### PR TITLE
Use celery-singleton to prevent celery task backlogs.

### DIFF
--- a/b3lb/loadbalancer/settings_base.py
+++ b/b3lb/loadbalancer/settings_base.py
@@ -119,6 +119,10 @@ CELERY_RESULT_BACKEND = 'django-db'
 
 CELERY_RESULT_EXPIRES = 3600
 
+# Lock expiry time in second for singleton task locks.
+
+CELERY_SINGLETON_LOCK_EXPIRY = 300
+
 
 # Internationalization
 # https://docs.djangoproject.com/en/3.1/topics/i18n/

--- a/b3lb/requirements.txt
+++ b/b3lb/requirements.txt
@@ -2,6 +2,7 @@ Django==3.1.7
 django-extensions==3.1.1
 requests==2.25.1
 celery==5.0.5
+celery-singleton==0.3.1
 django-cacheops==5.1
 django-celery-admin==0.1
 django-celery-beat==2.2.0


### PR DESCRIPTION
A task backlog may occur if the celery workers do not have enough throughput. This might be triggered by non-responsive BBB nodes or adding a bunch of new BBB nodes. This results in a memory exhausting on the redis broker.

Using *celery-singleton* will prevent scheduling check tasks for a single node more than once.