### PR TITLE
record endpoint fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # ChangeLog
 
+## 3.1.1 - 2023-09-28
+
+Fixes:
+- fix getRecordings endpoint when nothing is queried 
+- fix ConnectionError exception when sending callback to given url
+- fix filter records when no meeting_id or record_id aren't UUIDs
+
+
 ## 3.1.0 - 2023-06-29
 
 Changes:

--- a/b3lb/rest/classes/api.py
+++ b/b3lb/rest/classes/api.py
@@ -30,7 +30,7 @@ from json import dumps
 from _hashlib import HASH
 from random import randint
 from requests import get
-from requests.exceptions import ConnectionError
+from requests.exceptions import RequestException
 from rest.b3lb.metrics import incr_metric, update_create_metrics
 from rest.b3lb.utils import get_checksum
 from rest.models import ClusterGroupRelation, Meeting, Metric, Node, Parameter, Record, RecordSet, Secret, SecretMeetingList, SecretMetricsList, Stats
@@ -630,7 +630,8 @@ class NodeB3lbRequest:
                 url = f"{end_callback_url}?meetingID={self.meeting_id}&recordingmarks={self.recording_marks}"
             try:
                 get(url)
-            except ConnectionError:
+            except RequestException as rex:
+                print(f"Exception: {rex}")
                 print(f"Couldn't send callback to URL: {url}")
 
     async def upload_record(self) -> HttpResponse:

--- a/b3lb/rest/classes/api.py
+++ b/b3lb/rest/classes/api.py
@@ -23,17 +23,19 @@ from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.files.base import ContentFile
 from django.db.models import Sum
-from django.db.models.query import QuerySet
+from django.db.models.query import QuerySet, Q
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect, HttpResponseBadRequest, HttpResponseForbidden
 from django.template.loader import render_to_string
 from json import dumps
 from _hashlib import HASH
 from random import randint
 from requests import get
+from requests.exceptions import ConnectionError
 from rest.b3lb.metrics import incr_metric, update_create_metrics
 from rest.b3lb.utils import get_checksum
 from rest.models import ClusterGroupRelation, Meeting, Metric, Node, Parameter, Record, RecordSet, Secret, SecretMeetingList, SecretMetricsList, Stats
 from typing import Any, Dict, List, Literal, Union
+from uuid import UUID
 from urllib.parse import urlencode
 from xmltodict import parse
 import rest.b3lb.contants as cst
@@ -118,7 +120,7 @@ class ClientB3lbRequest:
             for meeting_id in self.meeting_id.split(","):
                 records = await sync_to_async(self.get_recording_dicts)(records, meeting_id=meeting_id)
         else:
-            records = await sync_to_async(self.get_recording_dicts)()
+            records = await sync_to_async(self.get_recording_dicts)([])
 
         if records:
             return HttpResponse(render_to_string(template_name="getRecordings.xml", context={"records": records}), content_type=cst.CONTENT_TYPE)
@@ -277,21 +279,31 @@ class ClientB3lbRequest:
         return ["GET", "POST"]
 
     def filter_recordings(self, meeting_id: str = "", recording_id: str = "") -> QuerySet[Record]:
-        if recording_id:
-            recordings = Record.objects.filter(uuid=recording_id, record_set__secret=self.secret)
-        elif meeting_id:
-            recordings = Record.objects.filter(record_set__meta_meeting_id=meeting_id, record_set__secret=self.secret)
-        else:
-            recordings = Record.objects.filter(record_set__secret=self.secret)
+        if self.state and self.state not in ["unpublished", "published"]:
+            return QuerySet(model=Record)  # return empty QuerySet if state isn't in allowed states
 
-        if not self.state:
-            return recordings
-        elif self.state == "published":
-            return recordings.filter(published=True)
+        query = Q(record_set__secret=self.secret)
+
+        if recording_id:
+            try:
+                UUID(recording_id)
+                query &= Q(uuid=recording_id)
+            except ValueError:
+                return QuerySet(model=Record)  # return empty QuerySet for BadRequest
+
+        if meeting_id:
+            try:
+                UUID(meeting_id)
+                query %= Q(record_set__meta_meeting_id=meeting_id)
+            except ValueError:
+                return QuerySet(model=Record)  # return empty QuerySet for BadRequest
+
+        if self.state == "published":
+            query &= Q(published=True)
         elif self.state == "unpublished":
-            return recordings.filter(published=False)
-        else:
-            return QuerySet(model=Record)  # return empty QuerySet
+            query &= Q(published=True)
+
+        return Record.objects.filter(query)
 
     def delete_recordings_by_recording_id(self, recording_id: str = ""):
         recordings = self.filter_recordings(recording_id=recording_id)
@@ -616,7 +628,10 @@ class NodeB3lbRequest:
                 url = f"{end_callback_url}&meetingID={self.meeting_id}&recordingmarks={self.recording_marks}"
             else:
                 url = f"{end_callback_url}?meetingID={self.meeting_id}&recordingmarks={self.recording_marks}"
-            get(url)
+            try:
+                get(url)
+            except ConnectionError:
+                print(f"Couldn't send callback to URL: {url}")
 
     async def upload_record(self) -> HttpResponse:
         record_set: RecordSet

--- a/b3lb/rest/classes/api.py
+++ b/b3lb/rest/classes/api.py
@@ -301,7 +301,7 @@ class ClientB3lbRequest:
         if self.state == "published":
             query &= Q(published=True)
         elif self.state == "unpublished":
-            query &= Q(published=True)
+            query &= Q(published=False)
 
         return Record.objects.filter(query)
 

--- a/b3lb/rest/classes/api.py
+++ b/b3lb/rest/classes/api.py
@@ -120,7 +120,7 @@ class ClientB3lbRequest:
             for meeting_id in self.meeting_id.split(","):
                 records = await sync_to_async(self.get_recording_dicts)(records, meeting_id=meeting_id)
         else:
-            records = await sync_to_async(self.get_recording_dicts)([])
+            records = await sync_to_async(self.get_recording_dicts)(records)
 
         if records:
             return HttpResponse(render_to_string(template_name="getRecordings.xml", context={"records": records}), content_type=cst.CONTENT_TYPE)


### PR DESCRIPTION
- fix getRecordings endpoint when nothing is queried
- fix ConnectionError exception when sending callback to given url
- fix filter records when meeting_id or record_id aren't UUIDs