### PR TITLE
recording: add clip only if information exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+# 3.2.5 - 2024-07-03
+
+Fixes:
+- missing check for no clips during rendering task 
+
 ## 3.2.4 - 2024-06-16
 
 Fixes:
@@ -23,7 +28,7 @@ Fixes:
 
 Changes:
 - adjust to BBB 2.7.8 API changes 
-  - forbid POST request for `join` endpoint
+  - forbid POST request for `join` endpoint ()
   - adjustments for POST headers are already handled
 - meeting name check:
   - add check for meeting name length for faster response without sending a request to backend systems

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Fixes:
 
 Changes:
 - adjust to BBB 2.7.8 API changes 
-  - forbid POST request for `join` endpoint ()
+  - forbid POST request for `join` endpoint
   - adjustments for POST headers are already handled
 - meeting name check:
   - add check for meeting name length for faster response without sending a request to backend systems

--- a/b3lb/rest/b3lb/make_xges.py
+++ b/b3lb/rest/b3lb/make_xges.py
@@ -260,12 +260,14 @@ class Presentation:
 
             # Find the width/height of the slide corresponding to this
             # point in time
-            info = [i.data for i in slide_time.at(pos.start)][0]
-            width, height = self._constrain(
-                (info.width, info.height),
-                (self.slides_width, self.opts.height))
+            info_list = [i.data for i in slide_time.at(pos.start)]
+            if info_list:
+                info = info_list[0]
+                width, height = self._constrain(
+                    (info.width, info.height),
+                    (self.slides_width, self.opts.height))
 
-            self._add_clip(cursor_layer, dot, pos.start, 0, end - pos.start, round(width*pos.x - dot_width/2), round(height*pos.y - dot_height / 2), dot_width, dot_height)
+                self._add_clip(cursor_layer, dot, pos.start, 0, end - pos.start, round(width*pos.x - dot_width/2), round(height*pos.y - dot_height / 2), dot_width, dot_height)
 
         layer = self._add_layer('Annotations')
         # Move above the slides layer


### PR DESCRIPTION
Fixes following bug:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/celery/app/trace.py", line 453, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/celery/app/trace.py", line 736, in __protected_call__
    return self.run(*args, **kwargs)
  File "/usr/src/app/rest/task/b3lb.py", line 44, in recording_render_record
    return render_record(RecordSet.objects.get(uuid=record_set_uuid))
  File "/usr/src/app/rest/task/recording.py", line 87, in render_record
    record_id = render_by_profile(record_set, record_profile, tempdir)
  File "/usr/src/app/rest/task/recording.py", line 46, in render_by_profile
    render_xges(f"{tempdir}/in/", f"{tempdir}/out/video.xges", record_profile)
  File "/usr/src/app/rest/b3lb/make_xges.py", line 350, in render_xges
    p = Presentation(opts)
  File "/usr/src/app/rest/b3lb/make_xges.py", line 90, in __init__
    self.add_slides()
  File "/usr/src/app/rest/b3lb/make_xges.py", line 263, in add_slides
    info = [i.data for i in slide_time.at(pos.start)][0]
IndexError: list index out of range
```